### PR TITLE
Fix wrong exponent for HUF currency

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -932,7 +932,7 @@
     "symbol": "Ft",
     "alternate_symbols": [],
     "subunit": "",
-    "subunit_to_unit": 1,
+    "subunit_to_unit": 100,
     "symbol_first": false,
     "html_entity": "",
     "decimal_mark": ",",


### PR DESCRIPTION
Fix wrong exponent for HUF currency